### PR TITLE
now.json fix

### DIFF
--- a/python/buy-elephant/now/now.json
+++ b/python/buy-elephant/now/now.json
@@ -3,7 +3,7 @@
   "builds": [
     {
       "src": "*.py",
-      "use": "@now/python"
+      "use": "@vercel/python"
     }
   ],
   "routes": [


### PR DESCRIPTION
Warning: @now/python@1.2.3: "@now/python" is deprecated and will stop receiving updates January 2021. Please use "@vercel/python" instead.